### PR TITLE
Rename a couple of labels

### DIFF
--- a/src/main/scala/com/full360/prometheus/client/http/HttpLatency.scala
+++ b/src/main/scala/com/full360/prometheus/client/http/HttpLatency.scala
@@ -31,8 +31,8 @@ trait HttpLatency extends Http with Latency {
   override val labels = Seq(
     "method",
     "host",
-    "uri",
-    "response"
+    "path",
+    "code"
   )
 
   def register(duration: Double, method: String, host: String, uri: String, response: Int) = {


### PR DESCRIPTION
Rename `uri` to `path` and `response` to `code`.