### PR TITLE
Fix generated Maven pom file and add JVM metrics helper method

### DIFF
--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -57,7 +57,7 @@ object Publish {
     credentials += credential,
     pomExtra := pom,
 
-    publishTo := Some("TLT Maven releases" at "http://nexus:8081/nexus/content/repositories/snapshots"),
+    publishTo := Some("TLT Maven releases" at "http://nexus:8081/nexus/content/repositories/releases"),
     updateOptions := updateOptions.value.withCachedResolution(true)
   )
 }

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -19,24 +19,23 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import com.typesafe.sbt.SbtPgp.autoImportImpl._
-import sbt.Keys._
-import sbt.{ Credentials, _ }
+import sbt.Keys.{publishTo, _}
+import sbt.{Credentials, _}
 
 object Publish {
 
   private lazy val credential = Credentials(
     "Sonatype Nexus Repository Manager",
-    "oss.sonatype.org",
+    sys.env.getOrElse("SONATYPE_REPO", "oss.sonatype.org"),
     sys.env.getOrElse("SONATYPE_USERNAME", ""),
     sys.env.getOrElse("SONATYPE_PASSWORD", "")
   )
 
   private lazy val pom = {
       <scm>
-        <connection>scm:git:github.com/full360/prometheus_client_scala.git</connection>
-        <developerConnection>scm:git:git@github.com:full360/prometheus_client_scala.git</developerConnection>
-        <url>github.com/full360/prometheus_client_scala.git</url>
+        <connection>scm:git:github.com/TeletronicsDotAe/prometheus_client_scala.git</connection>
+        <developerConnection>scm:git:git@github.com:TeletronicsDotAe/prometheus_client_scala.git</developerConnection>
+        <url>https://github.com/TeletronicsDotAe/prometheus_client_scala</url>
       </scm>
       <developers>
         <developer>
@@ -46,6 +45,10 @@ object Publish {
           <organization>Full 360 Inc</organization>
           <organizationUrl>http://www.full360.com</organizationUrl>
         </developer>
+        <developer>
+          <id>trym-moeller</id>
+          <name>Trym Moeller</name>
+        </developer>
       </developers>
   }
 
@@ -53,8 +56,14 @@ object Publish {
     publishMavenStyle := true,
     credentials += credential,
     pomExtra := pom,
-    pgpSecretRing := file(".secring.gpg"),
-    pgpPublicRing := file(".pubring.gpg"),
-    pgpPassphrase := sys.env.get("SONATYPE_KEY_PASSPHRASE").map(_.toArray)
+
+    publishTo := {
+      if ((version in ThisBuild).value.endsWith("SNAPSHOT")) {
+        Some("TLT Maven snapshots" at "http://nexus:8081/nexus/content/repositories/snapshots")
+      } else {
+        Some("TLT Maven releases" at "http://nexus:8081/nexus/content/repositories/releases")
+      }
+    },
+    updateOptions := updateOptions.value.withCachedResolution(true)
   )
 }

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -57,7 +57,7 @@ object Publish {
     credentials += credential,
     pomExtra := pom,
 
-    publishTo := Some("TLT Maven releases" at "http://nexus:8081/nexus/content/repositories/releases"),
+    publishTo := Some("TLT Maven releases" at "http://nexus:8081/nexus/content/repositories/snapshots"),
     updateOptions := updateOptions.value.withCachedResolution(true)
   )
 }

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -33,13 +33,6 @@ object Publish {
   )
 
   private lazy val pom = {
-    <url>https://github.com/full360/prometheus_client_scala</url>
-      <licenses>
-        <license>
-          <name>MIT License</name>
-          <url>http://www.opensource.org/licenses/mit-license.php</url>
-        </license>
-      </licenses>
       <scm>
         <connection>scm:git:github.com/full360/prometheus_client_scala.git</connection>
         <developerConnection>scm:git:git@github.com:full360/prometheus_client_scala.git</developerConnection>

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -57,13 +57,7 @@ object Publish {
     credentials += credential,
     pomExtra := pom,
 
-    publishTo := {
-      if ((version in ThisBuild).value.endsWith("SNAPSHOT")) {
-        Some("TLT Maven snapshots" at "http://nexus:8081/nexus/content/repositories/snapshots")
-      } else {
-        Some("TLT Maven releases" at "http://nexus:8081/nexus/content/repositories/releases")
-      }
-    },
+    publishTo := Some("TLT Maven releases" at "http://nexus:8081/nexus/content/repositories/releases"),
     updateOptions := updateOptions.value.withCachedResolution(true)
   )
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -32,7 +32,7 @@ object Settings {
   private lazy val base = Seq(
     name := "prometheus-client-scala",
     organization := "com.full360",
-    version := "0.3-beta-SNAPSHOT",
+    version := "0.3-beta",
     licenses := Seq("The MIT License" -> url("https://opensource.org/licenses/MIT")),
     homepage := Some(url("https://github.com/full360/prometheus_client_scala")),
     scalaVersion := "2.11.8",

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -32,7 +32,7 @@ object Settings {
   private lazy val base = Seq(
     name := "prometheus-client-scala",
     organization := "com.full360",
-    version := "0.3-alpha",
+    version := "0.3-beta-SNAPSHOT",
     licenses := Seq("The MIT License" -> url("https://opensource.org/licenses/MIT")),
     homepage := Some(url("https://github.com/full360/prometheus_client_scala")),
     scalaVersion := "2.11.8",

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -32,7 +32,7 @@ object Settings {
   private lazy val base = Seq(
     name := "prometheus-client-scala",
     organization := "com.full360",
-    version := "0.3-SNAPSHOT",
+    version := "0.3-alpha",
     licenses := Seq("The MIT License" -> url("https://opensource.org/licenses/MIT")),
     homepage := Some(url("https://github.com/full360/prometheus_client_scala")),
     scalaVersion := "2.11.8",

--- a/src/main/scala/com/full360/prometheus/client/metric/Metric.scala
+++ b/src/main/scala/com/full360/prometheus/client/metric/Metric.scala
@@ -22,8 +22,8 @@
 package com.full360.prometheus.client.metric
 
 import com.full360.prometheus.client.util.Implicits._
-
-import io.prometheus.client.CollectorRegistry
+import io.prometheus.client.{Collector, CollectorRegistry}
+import io.prometheus.client.hotspot._
 
 trait Metric {
 
@@ -44,4 +44,15 @@ object Metric {
   override def toString = registry
     .metricFamilySamples()
     .asString
+
+  def addJVMMetrics() = {
+    // See io.prometheus.client.hotspot.DefaultExports.initialize()
+    new StandardExports().register[Collector](registry)
+    new MemoryPoolsExports().register[Collector](registry)
+    new GarbageCollectorExports().register[Collector](registry)
+    new ThreadExports().register[Collector](registry)
+    new ClassLoadingExports().register[Collector](registry)
+    new VersionInfoExports().register[Collector](registry)
+  }
+
 }

--- a/src/main/scala/com/full360/prometheus/client/metric/Metric.scala
+++ b/src/main/scala/com/full360/prometheus/client/metric/Metric.scala
@@ -40,23 +40,24 @@ trait Metric {
 object Metric {
 
   val registry = new CollectorRegistry(true)
-  private var addedJVMMetrics = false
 
   override def toString = registry
     .metricFamilySamples()
     .asString
 
+  /** Expose the clear method used when testing */
+  def clearRegistry() = {
+    registry.clear()
+  }
+
+  /** See io.prometheus.client.hotspot.DefaultExports.initialize() */
   def addJVMMetrics() = {
-    if (!addedJVMMetrics) {
-      // See io.prometheus.client.hotspot.DefaultExports.initialize()
-      new StandardExports().register[Collector](registry)
-      new MemoryPoolsExports().register[Collector](registry)
-      new GarbageCollectorExports().register[Collector](registry)
-      new ThreadExports().register[Collector](registry)
-      new ClassLoadingExports().register[Collector](registry)
-      new VersionInfoExports().register[Collector](registry)
-      addedJVMMetrics = true
-    }
+    new StandardExports().register[Collector](registry)
+    new MemoryPoolsExports().register[Collector](registry)
+    new GarbageCollectorExports().register[Collector](registry)
+    new ThreadExports().register[Collector](registry)
+    new ClassLoadingExports().register[Collector](registry)
+    new VersionInfoExports().register[Collector](registry)
   }
 
 }

--- a/src/main/scala/com/full360/prometheus/client/metric/Metric.scala
+++ b/src/main/scala/com/full360/prometheus/client/metric/Metric.scala
@@ -22,7 +22,7 @@
 package com.full360.prometheus.client.metric
 
 import com.full360.prometheus.client.util.Implicits._
-import io.prometheus.client.{Collector, CollectorRegistry}
+import io.prometheus.client.{ Collector, CollectorRegistry }
 import io.prometheus.client.hotspot._
 
 trait Metric {
@@ -40,19 +40,23 @@ trait Metric {
 object Metric {
 
   val registry = new CollectorRegistry(true)
+  private var addedJVMMetrics = false
 
   override def toString = registry
     .metricFamilySamples()
     .asString
 
   def addJVMMetrics() = {
-    // See io.prometheus.client.hotspot.DefaultExports.initialize()
-    new StandardExports().register[Collector](registry)
-    new MemoryPoolsExports().register[Collector](registry)
-    new GarbageCollectorExports().register[Collector](registry)
-    new ThreadExports().register[Collector](registry)
-    new ClassLoadingExports().register[Collector](registry)
-    new VersionInfoExports().register[Collector](registry)
+    if (!addedJVMMetrics) {
+      // See io.prometheus.client.hotspot.DefaultExports.initialize()
+      new StandardExports().register[Collector](registry)
+      new MemoryPoolsExports().register[Collector](registry)
+      new GarbageCollectorExports().register[Collector](registry)
+      new ThreadExports().register[Collector](registry)
+      new ClassLoadingExports().register[Collector](registry)
+      new VersionInfoExports().register[Collector](registry)
+      addedJVMMetrics = true
+    }
   }
 
 }


### PR DESCRIPTION
The generated maven pom file (used when releasing to a maven repository) is invalid as url and license information is duplicated. This should be fixed.

Added the DefaultExports.initialize() method to Metric to utilize the private CollectorRegistry.