### PR TITLE
Make the Akka HTTP Metric as a Service

### DIFF
--- a/src/main/scala/com/full360/prometheus/metrics/http/akka/AkkaHttpMetricService.scala
+++ b/src/main/scala/com/full360/prometheus/metrics/http/akka/AkkaHttpMetricService.scala
@@ -21,22 +21,26 @@
 
 package com.full360.prometheus.metrics.http.akka
 
-import com.full360.prometheus.BaseSpec
+import com.full360.prometheus.Metric
+import akka.http.scaladsl.server.Directives.{ complete, get, path }
+import akka.http.scaladsl.server.{ PathMatchers, Route }
 
-import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+object AkkaHttpMetricService {
+  private[akka] def metricsBase(path: String) = PathMatchers.separateOnSlashes(path)
+}
 
-class AkkaHttpMetricSpec extends BaseSpec with ScalatestRouteTest with AkkaHttpMetric {
+trait AkkaHttpMetricConfig {
+  def metricsBasePath: String = "metrics"
+}
 
-  "Akka Http" should provide {
-    "an endpoint" which {
-      "expose the metric registry" in {
+trait AkkaHttpMetricService extends AkkaHttpMetricConfig {
+  import AkkaHttpMetricService._
 
-        Get("/metrics") ~> metric ~> check {
-          handled shouldBe true
-          responseAs[String] shouldBe ""
-          status shouldBe StatusCodes.OK
-        }
+  def route: Route = {
+    val base = metricsBase(metricsBasePath)
+    path(base) {
+      get {
+        complete(Metric.getRegistry)
       }
     }
   }

--- a/src/test/scala/com/full360/prometheus/metrics/http/akka/AkkaHttpMetricServiceSpec.scala
+++ b/src/test/scala/com/full360/prometheus/metrics/http/akka/AkkaHttpMetricServiceSpec.scala
@@ -26,13 +26,27 @@ import com.full360.prometheus.BaseSpec
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 
-class AkkaHttpMetricServiceSpec extends BaseSpec with ScalatestRouteTest with AkkaHttpMetricService {
-
+class AkkaHttpMetricServiceSpec extends BaseSpec with ScalatestRouteTest {
   "Akka Http" should provide {
-    "an endpoint" which {
-      "expose the metric registry" in {
+    "a default endpoint" which {
+      "exposes the metric registry" in {
+        val promeService = new AkkaHttpMetricService {}
 
-        Get("/metrics") ~> route ~> check {
+        Get("/metrics") ~> promeService.route ~> check {
+          handled shouldBe true
+          responseAs[String] shouldBe ""
+          status shouldBe StatusCodes.OK
+        }
+      }
+    }
+
+    "a custom endpoint" which {
+      "exposes the metric registry" in {
+        val promService = new AkkaHttpMetricService {
+          override val metricsBasePath: String = "metricsv1"
+        }
+
+        Get("/metricsv1") ~> promService.route ~> check {
           handled shouldBe true
           responseAs[String] shouldBe ""
           status shouldBe StatusCodes.OK

--- a/src/test/scala/com/full360/prometheus/metrics/http/akka/AkkaHttpMetricServiceSpec.scala
+++ b/src/test/scala/com/full360/prometheus/metrics/http/akka/AkkaHttpMetricServiceSpec.scala
@@ -21,15 +21,23 @@
 
 package com.full360.prometheus.metrics.http.akka
 
-import com.full360.prometheus.Metric
+import com.full360.prometheus.BaseSpec
 
-import akka.http.scaladsl.server.Directives.{ complete, get, path }
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.testkit.ScalatestRouteTest
 
-trait AkkaHttpMetric {
+class AkkaHttpMetricServiceSpec extends BaseSpec with ScalatestRouteTest with AkkaHttpMetricService {
 
-  def metric = path("metrics") {
-    get {
-      complete(Metric.getRegistry)
+  "Akka Http" should provide {
+    "an endpoint" which {
+      "expose the metric registry" in {
+
+        Get("/metrics") ~> route ~> check {
+          handled shouldBe true
+          responseAs[String] shouldBe ""
+          status shouldBe StatusCodes.OK
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
The metric path should be configurable, and we can achieve that doing
something like this. Still some work left.